### PR TITLE
feat: add Atlassian service account authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,57 @@ See all available commands:
 jira-ai --help
 ```
 
+## Service Account Authentication
+
+Atlassian service accounts use scoped API tokens that must authenticate through the `api.atlassian.com` gateway rather than direct site URLs.
+
+### Using a `.env` file
+
+Create a `.env` file with your service account credentials:
+
+```env
+JIRA_HOST=your-domain.atlassian.net
+JIRA_USER_EMAIL=your-bot@serviceaccount.atlassian.com
+JIRA_API_TOKEN=your-service-account-api-token
+JIRA_AUTH_TYPE=service_account
+```
+
+Then authenticate:
+
+```bash
+jira-ai auth --from-file path/to/.env
+```
+
+The Cloud ID will be auto-discovered from your site URL. To provide it explicitly:
+
+```env
+JIRA_CLOUD_ID=your-cloud-id
+```
+
+### Using CLI flags
+
+```bash
+jira-ai auth --service-account
+```
+
+Or with an explicit Cloud ID:
+
+```bash
+jira-ai auth --service-account --cloud-id your-cloud-id
+```
+
+### How it works
+
+Standard Jira API tokens authenticate directly against `your-domain.atlassian.net`. Service account tokens are scoped and must route through the Atlassian API gateway at `api.atlassian.com/ex/jira/{cloudId}/...`.
+
+When `authType` is set to `service_account`, jira-ai automatically:
+
+1. Discovers your Cloud ID from `https://your-domain.atlassian.net/_edge/tenant_info` (if not provided)
+2. Routes all API requests through `https://api.atlassian.com/ex/jira/{cloudId}` instead of the direct site URL
+3. Uses the same basic auth (email + API token) — just through the gateway
+
+Existing configurations using standard API tokens are unaffected.
+
 ## Configuration & Restrictions
 
 Tool allows you to have very complex configutations of what Projects/Jira commands/Issue types you would have acess to thought the tool.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jira-ai",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jira-ai",
-      "version": "0.9.8",
+      "version": "0.9.9",
       "license": "Apache-2.0",
       "dependencies": {
         "adf-to-markdown": "^1.0.1",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -133,6 +133,8 @@ program
   .option('--from-file <path>', 'Accepts a path to a file (typically .env) with credentials')
   .option('--alias <alias>', 'Alias for this organization')
   .option('--logout', 'Logout from all organizations')
+  .option('--service-account', 'Use Atlassian service account auth via api.atlassian.com gateway')
+  .option('--cloud-id <id>', 'Atlassian Cloud ID (auto-discovered if not provided)')
   .action((options) => authCommand(options))
   .command('logout')
   .description('Logout from all organizations')

--- a/src/lib/auth-storage.ts
+++ b/src/lib/auth-storage.ts
@@ -6,6 +6,8 @@ export interface AuthCredentials {
   host: string;
   email: string;
   apiToken: string;
+  authType?: 'basic' | 'service_account';
+  cloudId?: string;
 }
 
 export interface Config {


### PR DESCRIPTION
This pull request introduces support for Atlassian service account authentication in the `jira-ai` CLI, enabling users to authenticate via the `api.atlassian.com` gateway using scoped API tokens. The changes include new CLI options, automatic Cloud ID discovery, and updates to credential handling and documentation. Existing authentication flows remain unaffected.

**Service account authentication support:**

* Added `--service-account` and `--cloud-id` CLI options to the `auth` command, allowing users to specify service account authentication and provide or auto-discover the Atlassian Cloud ID.
* Updated `authCommand` logic to detect service account credentials from CLI options or `.env` files, auto-discover the Cloud ID if not provided, and route authentication through the Atlassian API gateway. [[1]](diffhunk://#diff-e7f669a16cb4ecffee825c7752a80d11b708e5e471aefb2f95b6f1187f8da78eR66-R67) [[2]](diffhunk://#diff-e7f669a16cb4ecffee825c7752a80d11b708e5e471aefb2f95b6f1187f8da78eR98-R105) [[3]](diffhunk://#diff-e7f669a16cb4ecffee825c7752a80d11b708e5e471aefb2f95b6f1187f8da78eR144-R178)
* Extended credential storage to include `authType` and `cloudId` fields for distinguishing between standard and service account authentication.

**Jira client enhancements:**

* Introduced `resolveHost` utility to select the correct API endpoint (`api.atlassian.com/ex/jira/{cloudId}` for service accounts, direct site URL otherwise), and updated client initialization logic to use this function for both persistent and temporary clients. [[1]](diffhunk://#diff-1793dce54cd255188262d5f30c346b0800cd64eaf266c351e0fe2a6421181a6eR182-R192) [[2]](diffhunk://#diff-1793dce54cd255188262d5f30c346b0800cd64eaf266c351e0fe2a6421181a6eR201-R203) [[3]](diffhunk://#diff-1793dce54cd255188262d5f30c346b0800cd64eaf266c351e0fe2a6421181a6eL212-R232)

**Documentation updates:**

* Added a detailed section to `README.md` explaining service account authentication, including usage examples for both CLI flags and `.env` files, Cloud ID discovery, and how the new flow works.